### PR TITLE
Support Spec-based limits and increment in midiEncoder input.

### DIFF
--- a/Classes/CWMain.sc
+++ b/Classes/CWMain.sc
@@ -99,12 +99,12 @@ ClockWise {
             ch, spec, unmapped);
     }
 
-    midiEncoder { |pt, dev, ch, cc, increment, mode=\universal, inOnly=false, outOnly=false|
+    midiEncoder { |pt, dev, ch, cc, spec = nil, mode=\universal, inOnly=false, outOnly=false|
         CWEncoder(
             this.point(pt),
             this.getMidiIn(dev, skip:outOnly),
             this.getMidiOut(dev, skip:inOnly),
-            ch, cc, increment, mode);
+            ch, cc, spec, mode);
     }
 
     midiRadioButton { |pt, value, dev, ch, note=nil, cc=nil, inOnly=false, outOnly=false|


### PR DESCRIPTION
Just a thought here, but since Specs are used elsewhere, it makes sense to use them on the MidiEncoder. Since encoders are effectively endless value sources, it makes sense to put sensible input bounds on them, both to constrain their potential values, and to provide more consistent mappings when multiple consumers are using the data. This uses a spec as the constraint provider, but you could use independent variables if you like - the mapping features of the spec are not used, just the increment, max, min, etc. 

I didn't support an "unmapped" mode since that would require manually specifying both an increment and infinity as the limits, and that's doable using a custom spec if desired, but I can see many other ways of accomplishing the same thing. In this case, I went with the pattern as close as possible to the other midiCC mappings.

Please note that this would be a breaking change to the API, as the increment values would cause a runtime error on update since the float won't respond to `step`. 