### PR TITLE
Sync after selection changes.

### DIFF
--- a/Classes/CWMain.sc
+++ b/Classes/CWMain.sc
@@ -162,11 +162,12 @@ ClockWise {
         );
     }
 
-    select { |commonPt, selectorPt, muxPts|
+    select { |commonPt, selectorPt, muxPts, sync = true|
         CWSelect(
             this.point(commonPt),
             this.point(selectorPt),
-            muxPts.collect ( this.point(_) )
+            muxPts.collect ( this.point(_) ),
+            sync
         );
     }
 

--- a/Classes/CWMain.sc
+++ b/Classes/CWMain.sc
@@ -162,12 +162,11 @@ ClockWise {
         );
     }
 
-    select { |commonPt, selectorPt, muxPts, sync = true|
+    select { |commonPt, selectorPt, muxPts|
         CWSelect(
             this.point(commonPt),
             this.point(selectorPt),
-            muxPts.collect ( this.point(_) ),
-            sync
+            muxPts.collect ( this.point(_) )
         );
     }
 

--- a/Classes/CWUtility.sc
+++ b/Classes/CWUtility.sc
@@ -2,13 +2,14 @@ CWSelect : CWControl {
     // Selects one of several points to join with another point, based on the
     // value of yet a third point!
 
-    var selection;
+    var selection, sync;
 
-    *new { | commonPoint, selectorPoint, muxPoints |
-        ^super.new().initSelect(commonPoint, selectorPoint, muxPoints)
+    *new { | commonPoint, selectorPoint, muxPoints, sync = true |
+        ^super.new().initSelect(commonPoint, selectorPoint, muxPoints, sync)
     }
-    initSelect { | commonPoint, selectorPoint, muxPoints |
+    initSelect { | commonPoint, selectorPoint, muxPoints, syncOpt |
         selection = 0;
+        sync = syncOpt;
 
         this.connect(commonPoint, \common);
         this.connect(selectorPoint);
@@ -24,7 +25,7 @@ CWSelect : CWControl {
         { id.isNil } { this.receive(msg, args); }
     }
 
-    set { |s| selection = s; }
+    set { |s| selection = s; if(sync) { this.sendTo(selection, \sync); }; }
 }
 
 

--- a/Classes/CWUtility.sc
+++ b/Classes/CWUtility.sc
@@ -2,20 +2,18 @@ CWSelect : CWControl {
     // Selects one of several points to join with another point, based on the
     // value of yet a third point!
 
-    var selection, sync;
+    var selection;
 
-    *new { | commonPoint, selectorPoint, muxPoints, sync = true |
-        ^super.new().initSelect(commonPoint, selectorPoint, muxPoints, sync)
+    *new { | commonPoint, selectorPoint, muxPoints |
+        ^super.new().initSelect(commonPoint, selectorPoint, muxPoints)
     }
-    initSelect { | commonPoint, selectorPoint, muxPoints, syncOpt |
-        selection = 0;
-        sync = syncOpt;
-
+    initSelect { | commonPoint, selectorPoint, muxPoints |
         this.connect(commonPoint, \common);
         this.connect(selectorPoint);
         muxPoints.do { |p, i|
             this.connect(p, i);
         };
+        self.set(0);
     }
 
     receiveId { |id, msg, args|
@@ -25,7 +23,12 @@ CWSelect : CWControl {
         { id.isNil } { this.receive(msg, args); }
     }
 
-    set { |s| selection = s; if(sync) { this.sendTo(selection, \sync); }; }
+    set { |s|
+        if (selection != s) {
+            selection = s;
+            points.at(s) !? _.sync();
+        };
+    }
 }
 
 

--- a/Classes/CWUtility.sc
+++ b/Classes/CWUtility.sc
@@ -13,7 +13,7 @@ CWSelect : CWControl {
         muxPoints.do { |p, i|
             this.connect(p, i);
         };
-        self.set(0);
+        this.set(0);
     }
 
     receiveId { |id, msg, args|


### PR DESCRIPTION
Another small tweak. If a select changes, the /common node isn't updated with the new and possibly different value of the destination nodes. Where possible, sync on change to ensure that (e.g.) encoders are set to the right values.

I added a guard option to turn this off if you like. You can set the default to false if you prefer, for backward compatibility. I was however surprised that it didn't sync, so maybe the principle of least surprise would suggest we default it to true, but I really don't feel strongly either way. 