### PR TITLE
Add sysex handler

### DIFF
--- a/Classes/CWMain.sc
+++ b/Classes/CWMain.sc
@@ -39,7 +39,7 @@ ClockWise {
                 try {
 					MIDIIn.connect(i, ep)
 				} { |err|
-					if (err.isKindOf(PrimitiveFailedError)) 
+					if (err.isKindOf(PrimitiveFailedError))
 						{ "You can ignore that error message.".postln; }
 						{ err.throw; };
 				};
@@ -54,7 +54,7 @@ ClockWise {
 				try {
 					m.connect(ep.uid);
 				} { |err|
-					if (err.isKindOf(PrimitiveFailedError)) 
+					if (err.isKindOf(PrimitiveFailedError))
 						{ "You can ignore that error message.".postln; }
 						{ err.throw; };
 				};
@@ -145,6 +145,12 @@ ClockWise {
             this.getMidiIn(dev, skip:outOnly),
             this.getMidiOut(dev, skip:inOnly),
             ch);
+    }
+
+    sysex { |dev, callback|
+        CWSysex(
+            this.getMidiIn(dev),
+            callback);
     }
 
     tempoClock { |tempoPt, clockPt, clock|

--- a/Classes/CWMidiControl.sc
+++ b/Classes/CWMidiControl.sc
@@ -160,5 +160,21 @@ CWProgram : CWControl {
     trigger { |v| midiSend !? _.(v) }
 }
 
+CWSysex : CWControl {
+    // map sysex to a handler function
+    var midiFunc;
 
-
+    *new { |devId, callback|
+        ^super.new().initSysex(devId, callback)
+    }
+    initSysex { |devId, callback|
+        if (devId.isNil.not) {
+            midiFunc = MIDIFunc.sysex(callback, devId);
+        };
+    }
+    free {
+        midiFunc.free;
+        midiFunc = nil;
+        super.free;
+    }
+}

--- a/Classes/CWUtility.sc
+++ b/Classes/CWUtility.sc
@@ -109,4 +109,3 @@ CWWarp : CWControl {
     toWarp { |b| this.sendTo(\warp, \set, warp.map(b)); }
     toBase { |w| this.sendTo(\base, \set, warp.unmap(w)); }
 }
-


### PR DESCRIPTION
Adds a method to easily set up a sysex handler function callback on a device point by symbol.

Example use case to dump H9 pedal preset sysex to post window:

```
(
{
  var handleSysex = { |data| data.postln; };

  ~cw = ClockWise({});
  ~cw.midiDevice(\h9, "H9 Pedal");
  ~cw.sysex(\h9, handleSysex);
}.value;

// Request pedal current program via sysex:
~cw.getMidiOut(\h9).sysex(Int8Array[ 0xF0, 0x1C, 0x70, 0, 0x4E, 0xF7]);
)
```