### PR TITLE
Add resane and hasResponder methods.

### DIFF
--- a/Classes/CWBase.sc
+++ b/Classes/CWBase.sc
@@ -59,6 +59,15 @@ CWPoint {
         ^nil
     }
 
+    hasResponder { |symbol|
+        connections.do { |conn|
+            if (conn[0].respondsTo(symbol)) {
+                ^true;
+            }
+        };
+        ^false
+    }
+
     // convience methods
     sane { ^this.performFirst(\sane) }
     sync { ^this.performFirst(\sync) }

--- a/Classes/CWMain.sc
+++ b/Classes/CWMain.sc
@@ -188,7 +188,6 @@ ClockWise {
         );
     }
 
-
     set { |pt, nv| points.at(pt) !? (_.distribute(\set, nv)) }
 
     sane { |pt| points.at(pt) !? (_.sane) }

--- a/Classes/CWUtility.sc
+++ b/Classes/CWUtility.sc
@@ -51,6 +51,11 @@ CWSane : CWControl {
         this.set(saneValue);
         this.send(\set, saneValue);
     }
+
+    resane { |v|
+        saneValue = v;
+    }
+
     sync {
         this.send(\set, lastValue);
     }


### PR DESCRIPTION
Very useful for keeping sane state for external devices. Use case:

I want to snapshot a current state of a point or set of points to return to when I sane things. This might be capturing the pristine state of an external device preset or a particular starting point from which I want to diverge and then return to (sort of like the Elektron boxes have a save and reload feature for on-the-fly breakdowns and then sudden return to "normal"). Resaning the existing values will set the sane state for that device to a known good state relative to the current performance. Saning or saneAll, after that, will correctly restore the device to this known state. 

hasResponder is implemented in order to determine if a sane has already been setup on a given point and if I need to init it or resane it, accordingly. It might have other uses too - it's a convenient way to get respondTo for the point's connection list rather than the point itself. 